### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -3,6 +3,8 @@ on:
     types: [published]
 
 name: Publish Package
+permissions:
+  contents: read
 
 jobs:
   unit-tests:


### PR DESCRIPTION
Potential fix for [https://github.com/Agilo/medusa-analytics-plugin/security/code-scanning/1](https://github.com/Agilo/medusa-analytics-plugin/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow. The best approach is to set a restrictive default at the workflow level (e.g., `contents: read`), and then override it for jobs that require broader permissions. In this case, the `unit-tests` and `integration-tests` jobs only need to read repository contents, so `contents: read` is sufficient. The `publish` job, which publishes to npm, may require `contents: write` (if it needs to create tags or releases), but for publishing to npm, `contents: read` is usually enough unless the workflow also pushes changes or creates releases. If unsure, start with `contents: read` and increase only if necessary.

**Steps:**
- Add a `permissions: contents: read` block at the top level of the workflow (applies to all jobs).
- If the `publish` job requires more permissions, add a `permissions` block to that job with the required scopes (e.g., `contents: write`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
