### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
 jobs:
   unit-tests:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/Agilo/medusa-analytics-plugin/security/code-scanning/2](https://github.com/Agilo/medusa-analytics-plugin/security/code-scanning/2)

To fix the problem, we should add a `permissions` block to the workflow. Since neither job appears to require write access (they only check out code and run tests), the minimal required permission is `contents: read`. This block can be added at the root level of the workflow (above `jobs:`), which will apply to all jobs unless overridden. No changes to the jobs themselves are needed, and no additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
