### PR TITLE
Customers tab

### DIFF
--- a/integration-tests/fixtures/customers.ts
+++ b/integration-tests/fixtures/customers.ts
@@ -25,3 +25,45 @@ export async function createTestCustomer({
 
   return response.data.customer;
 }
+
+export async function createCustomerGroup({
+  api,
+  name,
+  adminHeaders,
+}: {
+  api: any;
+  name?: string;
+  adminHeaders: {};
+}) {
+  const response = await api.post(
+    '/admin/customer-groups',
+    {
+      name: name || 'Test Group',
+    },
+    adminHeaders
+  );
+
+  return response.data.customer_group;
+}
+
+export async function addCustomerToGroup({
+  api,
+  customerId,
+  groupId,
+  adminHeaders,
+}: {
+  api: any;
+  customerId: string;
+  groupId: string[];
+  adminHeaders: {};
+}) {
+  const response = await api.post(
+    `/admin/customers/${customerId}/customer-groups`,
+    {
+      add: groupId,
+    },
+    adminHeaders
+  );
+
+  return response.data;
+}

--- a/integration-tests/fixtures/customers.ts
+++ b/integration-tests/fixtures/customers.ts
@@ -1,0 +1,27 @@
+import { AdminCustomer } from '@medusajs/types';
+
+export async function createTestCustomer({
+  api,
+  customerOverride,
+  adminHeaders,
+}: {
+  api: any;
+  customerOverride?: Partial<AdminCustomer>;
+  adminHeaders: {};
+}) {
+  const defaultCustomer = {
+    email: 'customer@gmail.com',
+    first_name: 'Test',
+    last_name: 'Test',
+  };
+
+  const customerData = { ...defaultCustomer, ...customerOverride };
+
+  const response = await api.post(
+    '/admin/customers',
+    customerData,
+    adminHeaders
+  );
+
+  return response.data.customer;
+}

--- a/integration-tests/fixtures/orders.ts
+++ b/integration-tests/fixtures/orders.ts
@@ -58,6 +58,7 @@ export async function createOrderSeeder({
   fulfillmentSetsOverride,
   regionOverride,
   createdAt,
+  customerEmail
 }: {
   api: any;
   container: MedusaContainer;
@@ -74,6 +75,7 @@ export async function createOrderSeeder({
   adminHeaders: {};
   regionOverride?: AdminRegion;
   createdAt?: string;
+  customerEmail?: string;
 }) {
   const repo = container.resolve(ContainerRegistrationKeys.PG_CONNECTION);
   const publishableKey = await generatePublishableKey(container);
@@ -266,7 +268,7 @@ export async function createOrderSeeder({
       `/store/carts`,
       {
         currency_code: 'eur',
-        email: 'test@test.com',
+        email: customerEmail || 'test@test.com',
         region_id: region.id,
         shipping_address: {
           address_1: 'test address 1',

--- a/integration-tests/http/agilo-analytics.spec.ts
+++ b/integration-tests/http/agilo-analytics.spec.ts
@@ -11,8 +11,9 @@ import {
 } from '@medusajs/framework/types';
 import jwt from 'jsonwebtoken';
 import { createOrderSeeder } from '../fixtures/orders';
-import { createProductVariant } from '../fixtures/products';
+import { createTestCustomer } from '../fixtures/customers';
 import { endOfMonth, format, startOfMonth, subMonths } from 'date-fns';
+import { createProductVariant } from '../fixtures/products';
 
 jest.setTimeout(30000);
 
@@ -554,6 +555,159 @@ medusaIntegrationTestRunner({
           expect(foundVariant).toBeDefined();
           expect(foundVariant.sku).toBe(variant.sku);
           expect(foundVariant.inventoryQuantity).toBe(0);
+        });
+      });
+      describe('/customers', () => {
+        it('should return 401 if no authorization header', async () => {
+          const start = addDays(new Date(), -7);
+          const end = addDays(new Date(), 0);
+          await expect(
+            api.get(
+              `/admin/agilo-analytics/customers?date_from=${start}&date_to=${end}`
+            )
+          ).rejects.toMatchObject({
+            response: { status: 401 },
+          });
+        });
+
+        it('should return 400 when custom preset is missing date_from or date_to', async () => {
+          await expect(
+            api.get('/admin/agilo-analytics/customers?date_from=2024-01-01', {
+              headers,
+            })
+          ).rejects.toMatchObject({
+            response: { status: 400 },
+          });
+          await expect(
+            api.get('/admin/agilo-analytics/customers?date_to=2024-01-31', {
+              headers,
+            })
+          ).rejects.toMatchObject({
+            response: { status: 400 },
+          });
+        });
+        it('should return 500 for invalid date format', async () => {
+          await expect(
+            api.get(
+              '/admin/agilo-analytics/customers?date_from=not-a-date&date_to=2024-01-31',
+              { headers }
+            )
+          ).rejects.toMatchObject({
+            response: { status: 500 },
+          });
+        });
+        it('should return 200 and expected keys', async () => {
+          const start = addDays(new Date(), -7);
+          const end = addDays(new Date(), 0);
+
+          const res = await api.get(
+            `/admin/agilo-analytics/customers?date_from=${start}&date_to=${end}`,
+            { headers }
+          );
+
+          expect(res.status).toEqual(200);
+          expect(res.data).toHaveProperty('total_customers');
+          expect(res.data).toHaveProperty('new_customers');
+          expect(res.data).toHaveProperty('returning_customers');
+          expect(res.data).toHaveProperty('customer_count');
+          expect(res.data).toHaveProperty('customer_group');
+          expect(res.data).toHaveProperty('customer_sales');
+          expect(res.data).toHaveProperty('currency_code');
+        });
+        it('should return correct total customers based on seeded order', async () => {
+          const start = addDays(new Date(), -7);
+          const end = addDays(new Date(), 0);
+
+          const res = await api.get(
+            `/admin/agilo-analytics/customers?date_from=${start}&date_to=${end}`,
+            { headers }
+          );
+
+          expect(res.status).toEqual(200);
+          expect(res.data.total_customers).toBeGreaterThanOrEqual(1);
+          expect(res.data.new_customers).toBeGreaterThanOrEqual(1);
+          expect(res.data.returning_customers).toBeGreaterThanOrEqual(0);
+          expect(res.data.currency_code).toBe('EUR');
+        });
+        it('should return correct returning customers based on seeded order', async () => {
+          const start = addDays(new Date(), -7);
+          const end = addDays(new Date(), 0);
+
+          await createOrderSeeder({
+            api,
+            container: getContainer(),
+            adminHeaders: { headers },
+            productOverride: product,
+            stockChannelOverride: stockLocation,
+            inventoryItemOverride: inventoryItem,
+            salesChannelOverride: salesChannel,
+            shippingProfileOverride: shippingProfile,
+            fulfillmentSetOverride: fulfillmentSet,
+            fulfillmentSetsOverride: fulfillmentSets,
+            regionOverride: region,
+            createdAt: addDays(new Date(), -10),
+          });
+
+          const res = await api.get(
+            `/admin/agilo-analytics/customers?date_from=${start}&date_to=${end}`,
+            { headers }
+          );
+
+          expect(res.status).toEqual(200);
+          expect(res.data.new_customers).toBeGreaterThanOrEqual(0);
+          expect(res.data.returning_customers).toBeGreaterThanOrEqual(1);
+        });
+        it('should return correct new customer number based on multiple orders from different customers', async () => {
+          const start = addDays(new Date(), -7);
+          const end = addDays(new Date(), 0);
+
+          const customer1 = await createTestCustomer({
+            api,
+            adminHeaders: { headers },
+          });
+          const customer2 = await createTestCustomer({
+            api,
+            adminHeaders: { headers },
+            customerOverride: { email: 'customer2@example.com' },
+          });
+          await createOrderSeeder({
+            api,
+            container: getContainer(),
+            adminHeaders: { headers },
+            productOverride: product,
+            stockChannelOverride: stockLocation,
+            inventoryItemOverride: inventoryItem,
+            salesChannelOverride: salesChannel,
+            shippingProfileOverride: shippingProfile,
+            fulfillmentSetOverride: fulfillmentSet,
+            fulfillmentSetsOverride: fulfillmentSets,
+            regionOverride: region,
+            createdAt: addDays(new Date(), -2),
+            customerEmail: customer1.email,
+          });
+          await createOrderSeeder({
+            api,
+            container: getContainer(),
+            adminHeaders: { headers },
+            productOverride: product,
+            stockChannelOverride: stockLocation,
+            inventoryItemOverride: inventoryItem,
+            salesChannelOverride: salesChannel,
+            shippingProfileOverride: shippingProfile,
+            fulfillmentSetOverride: fulfillmentSet,
+            fulfillmentSetsOverride: fulfillmentSets,
+            regionOverride: region,
+            createdAt: addDays(new Date(), -1),
+            customerEmail: customer2.email,
+          });
+          const res = await api.get(
+            `/admin/agilo-analytics/customers?date_from=${start}&date_to=${end}`,
+            { headers }
+          );
+
+          expect(res.status).toEqual(200);
+          expect(res.data.new_customers).toBeGreaterThanOrEqual(3);
+          expect(res.data.returning_customers).toBeGreaterThanOrEqual(0);
         });
       });
     });

--- a/integration-tests/http/agilo-analytics.spec.ts
+++ b/integration-tests/http/agilo-analytics.spec.ts
@@ -11,8 +11,13 @@ import {
 } from '@medusajs/framework/types';
 import jwt from 'jsonwebtoken';
 import { createOrderSeeder } from '../fixtures/orders';
-import { createTestCustomer } from '../fixtures/customers';
 import { endOfMonth, format, startOfMonth, subMonths } from 'date-fns';
+
+import {
+  addCustomerToGroup,
+  createCustomerGroup,
+  createTestCustomer,
+} from '../fixtures/customers';
 import { createProductVariant } from '../fixtures/products';
 
 jest.setTimeout(30000);
@@ -708,6 +713,254 @@ medusaIntegrationTestRunner({
           expect(res.status).toEqual(200);
           expect(res.data.new_customers).toBeGreaterThanOrEqual(3);
           expect(res.data.returning_customers).toBeGreaterThanOrEqual(0);
+        });
+        it('should return correct new and returning customer numbers based on multiple orders from the same customer', async () => {
+          const start = addDays(new Date(), -7);
+          const end = addDays(new Date(), 0);
+
+          const customer1 = await createTestCustomer({
+            api,
+            adminHeaders: { headers },
+          });
+          const customer2 = await createTestCustomer({
+            api,
+            adminHeaders: { headers },
+            customerOverride: { email: 'customer2@example.com' },
+          });
+          await createOrderSeeder({
+            api,
+            container: getContainer(),
+            adminHeaders: { headers },
+            productOverride: product,
+            stockChannelOverride: stockLocation,
+            inventoryItemOverride: inventoryItem,
+            salesChannelOverride: salesChannel,
+            shippingProfileOverride: shippingProfile,
+            fulfillmentSetOverride: fulfillmentSet,
+            fulfillmentSetsOverride: fulfillmentSets,
+            regionOverride: region,
+            createdAt: addDays(new Date(), -2),
+            customerEmail: customer1.email,
+          });
+          await createOrderSeeder({
+            api,
+            container: getContainer(),
+            adminHeaders: { headers },
+            productOverride: product,
+            stockChannelOverride: stockLocation,
+            inventoryItemOverride: inventoryItem,
+            salesChannelOverride: salesChannel,
+            shippingProfileOverride: shippingProfile,
+            fulfillmentSetOverride: fulfillmentSet,
+            fulfillmentSetsOverride: fulfillmentSets,
+            regionOverride: region,
+            createdAt: addDays(new Date(), -1),
+            customerEmail: customer2.email,
+          });
+          await createOrderSeeder({
+            api,
+            container: getContainer(),
+            adminHeaders: { headers },
+            productOverride: product,
+            stockChannelOverride: stockLocation,
+            inventoryItemOverride: inventoryItem,
+            salesChannelOverride: salesChannel,
+            shippingProfileOverride: shippingProfile,
+            fulfillmentSetOverride: fulfillmentSet,
+            fulfillmentSetsOverride: fulfillmentSets,
+            regionOverride: region,
+            createdAt: addDays(new Date(), -15),
+            customerEmail: customer2.email,
+          });
+          const res = await api.get(
+            `/admin/agilo-analytics/customers?date_from=${start}&date_to=${end}`,
+            { headers }
+          );
+
+          expect(res.status).toEqual(200);
+          expect(res.data.new_customers).toEqual(2);
+          expect(res.data.returning_customers).toEqual(1);
+        });
+        it('should correctly calculate sales per customer', async () => {
+          const start = addDays(new Date(), -7);
+          const end = addDays(new Date(), 0);
+
+          const customer = await createTestCustomer({
+            api,
+            adminHeaders: { headers },
+          });
+
+          await createOrderSeeder({
+            api,
+            container: getContainer(),
+            adminHeaders: { headers },
+            productOverride: product,
+            stockChannelOverride: stockLocation,
+            inventoryItemOverride: inventoryItem,
+            salesChannelOverride: salesChannel,
+            shippingProfileOverride: shippingProfile,
+            fulfillmentSetOverride: fulfillmentSet,
+            fulfillmentSetsOverride: fulfillmentSets,
+            regionOverride: region,
+            createdAt: addDays(new Date(), -2),
+            customerEmail: customer.email,
+          });
+
+          await createOrderSeeder({
+            api,
+            container: getContainer(),
+            adminHeaders: { headers },
+            productOverride: product,
+            stockChannelOverride: stockLocation,
+            inventoryItemOverride: inventoryItem,
+            salesChannelOverride: salesChannel,
+            shippingProfileOverride: shippingProfile,
+            fulfillmentSetOverride: fulfillmentSet,
+            fulfillmentSetsOverride: fulfillmentSets,
+            regionOverride: region,
+            createdAt: addDays(new Date(), -1),
+            customerEmail: customer.email,
+          });
+
+          const res = await api.get(
+            `/admin/agilo-analytics/customers?date_from=${start}&date_to=${end}`,
+            { headers }
+          );
+
+          expect(res.status).toEqual(200);
+
+          const firstCustomer = res.data.customer_sales[0];
+          const secondCustomer = res.data.customer_sales[1];
+          expect(firstCustomer).toBeDefined();
+          expect(firstCustomer.sales).toEqual(2400);
+          expect(secondCustomer).toBeDefined();
+          expect(secondCustomer.sales).toEqual(1200);
+        });
+        it('should correctly calculate sales for a specific customer', async () => {
+          const start = addDays(new Date(), -7);
+          const end = addDays(new Date(), 0);
+
+          const customer = await createTestCustomer({
+            api,
+            adminHeaders: { headers },
+          });
+
+          await createOrderSeeder({
+            api,
+            container: getContainer(),
+            adminHeaders: { headers },
+            productOverride: product,
+            stockChannelOverride: stockLocation,
+            inventoryItemOverride: inventoryItem,
+            salesChannelOverride: salesChannel,
+            shippingProfileOverride: shippingProfile,
+            fulfillmentSetOverride: fulfillmentSet,
+            fulfillmentSetsOverride: fulfillmentSets,
+            regionOverride: region,
+            createdAt: addDays(new Date(), -2),
+            customerEmail: customer.email,
+          });
+
+          await createOrderSeeder({
+            api,
+            container: getContainer(),
+            adminHeaders: { headers },
+            productOverride: product,
+            stockChannelOverride: stockLocation,
+            inventoryItemOverride: inventoryItem,
+            salesChannelOverride: salesChannel,
+            shippingProfileOverride: shippingProfile,
+            fulfillmentSetOverride: fulfillmentSet,
+            fulfillmentSetsOverride: fulfillmentSets,
+            regionOverride: region,
+            createdAt: addDays(new Date(), -10),
+            customerEmail: customer.email,
+          });
+
+          const res = await api.get(
+            `/admin/agilo-analytics/customers?date_from=${start}&date_to=${end}`,
+            { headers }
+          );
+
+          expect(res.status).toEqual(200);
+
+          const firstCustomer = res.data.customer_sales.find(
+            (c) => c.email === customer.email
+          );
+
+          expect(firstCustomer).toBeDefined();
+          expect(firstCustomer.sales).toEqual(1200);
+        });
+        it('should correctly calculate sales for customer groups', async () => {
+          const start = addDays(new Date(), -7);
+          const end = addDays(new Date(), 0);
+
+          const customer = await createTestCustomer({
+            api,
+            adminHeaders: { headers },
+          });
+          const group = await createCustomerGroup({
+            api,
+            adminHeaders: { headers },
+          });
+          const group2 = await createCustomerGroup({
+            api,
+            adminHeaders: { headers },
+            name: 'VIP Customers',
+          });
+
+          await addCustomerToGroup({
+            api,
+            customerId: customer.id,
+            groupId: [group.id, group2.id],
+            adminHeaders: { headers },
+          });
+          await createOrderSeeder({
+            api,
+            container: getContainer(),
+            adminHeaders: { headers },
+            productOverride: product,
+            stockChannelOverride: stockLocation,
+            inventoryItemOverride: inventoryItem,
+            salesChannelOverride: salesChannel,
+            shippingProfileOverride: shippingProfile,
+            fulfillmentSetOverride: fulfillmentSet,
+            fulfillmentSetsOverride: fulfillmentSets,
+            regionOverride: region,
+            createdAt: addDays(new Date(), -2),
+            customerEmail: customer.email,
+          });
+          await createOrderSeeder({
+            api,
+            container: getContainer(),
+            adminHeaders: { headers },
+            productOverride: product,
+            stockChannelOverride: stockLocation,
+            inventoryItemOverride: inventoryItem,
+            salesChannelOverride: salesChannel,
+            shippingProfileOverride: shippingProfile,
+            fulfillmentSetOverride: fulfillmentSet,
+            fulfillmentSetsOverride: fulfillmentSets,
+            regionOverride: region,
+            createdAt: addDays(new Date(), -5),
+            customerEmail: customer.email,
+          });
+          const res = await api.get(
+            `/admin/agilo-analytics/customers?date_from=${start}&date_to=${end}`,
+            { headers }
+          );
+
+          expect(res.status).toEqual(200);
+          const groupData = res.data.customer_group.find(
+            (g) => g.name === group.name
+          );
+          const groupData2 = res.data.customer_group.find(
+            (g) => g.name === group2.name
+          );
+          expect(groupData).toBeDefined();
+          expect(groupData.total).toEqual(2400);
+          expect(groupData2).toBeDefined();
+          expect(groupData2.total).toEqual(2400);
         });
       });
     });

--- a/src/admin/components/CustomersTable.tsx
+++ b/src/admin/components/CustomersTable.tsx
@@ -24,7 +24,7 @@ type CustomersTableProps = {
 };
 
 const columnHelper =
-  createDataTableColumnHelper<CustomersTableProps['customers'][0]>();
+  createDataTableColumnHelper<CustomersTableProps['customers'][number]>();
 
 const PAGE_SIZE = 10;
 
@@ -40,7 +40,7 @@ export const CustomersTable: React.FC<CustomersTableProps> = ({
   const [search, setSearch] = React.useState<string>('');
 
   const [sorting, setSorting] = React.useState<DataTableSortingState | null>(
-    null
+    null,
   );
 
   const navigate = useNavigate();
@@ -49,7 +49,7 @@ export const CustomersTable: React.FC<CustomersTableProps> = ({
     let filtered = customers.filter(
       (customer) =>
         customer.name.toLowerCase().includes(search.toLowerCase()) ||
-        customer.email.toLowerCase().includes(search.toLowerCase())
+        customer.email.toLowerCase().includes(search.toLowerCase()),
     );
 
     if (sorting && sorting.id) {
@@ -70,7 +70,7 @@ export const CustomersTable: React.FC<CustomersTableProps> = ({
 
     return filtered.slice(
       pagination.pageIndex * pagination.pageSize,
-      (pagination.pageIndex + 1) * pagination.pageSize
+      (pagination.pageIndex + 1) * pagination.pageSize,
     );
   }, [customers, search, sorting, pagination]);
 
@@ -138,7 +138,7 @@ export const CustomersTable: React.FC<CustomersTableProps> = ({
         },
       }),
     ],
-    [currencyCode]
+    [currencyCode],
   );
 
   const table = useDataTable({

--- a/src/admin/components/CustomersTable.tsx
+++ b/src/admin/components/CustomersTable.tsx
@@ -1,0 +1,185 @@
+import * as React from 'react';
+import {
+  createDataTableColumnHelper,
+  useDataTable,
+  DataTable,
+  DataTablePaginationState,
+  DataTableSortingState,
+} from '@medusajs/ui';
+
+import { useNavigate } from 'react-router-dom';
+import { format } from 'date-fns';
+
+type CustomersTableProps = {
+  customers: {
+    customer_id: string;
+    name: string;
+    email: string;
+    order_count: number;
+    sales: number;
+    last_order: Date | null;
+    groups: string[];
+  }[];
+  currencyCode: string;
+};
+
+const columnHelper =
+  createDataTableColumnHelper<CustomersTableProps['customers'][0]>();
+
+const PAGE_SIZE = 10;
+
+export const CustomersTable: React.FC<CustomersTableProps> = ({
+  customers,
+  currencyCode,
+}) => {
+  const [pagination, setPagination] = React.useState<DataTablePaginationState>({
+    pageSize: PAGE_SIZE,
+    pageIndex: 0,
+  });
+
+  const [search, setSearch] = React.useState<string>('');
+
+  const [sorting, setSorting] = React.useState<DataTableSortingState | null>(
+    null
+  );
+
+  const navigate = useNavigate();
+
+  const shownCustomers = React.useMemo(() => {
+    let filtered = customers.filter(
+      (customer) =>
+        customer.name.toLowerCase().includes(search.toLowerCase()) ||
+        customer.email.toLowerCase().includes(search.toLowerCase())
+    );
+
+    if (sorting && sorting.id) {
+      filtered = filtered.slice().sort((a, b) => {
+        // @ts-expect-error - TypeScript does not know the type of sorting.id
+        const aVal = a[sorting.id];
+        // @ts-expect-error - TypeScript does not know the type of sorting.id
+        const bVal = b[sorting.id];
+        if (aVal < bVal) {
+          return sorting.desc ? 1 : -1;
+        }
+        if (aVal > bVal) {
+          return sorting.desc ? -1 : 1;
+        }
+        return 0;
+      });
+    }
+
+    return filtered.slice(
+      pagination.pageIndex * pagination.pageSize,
+      (pagination.pageIndex + 1) * pagination.pageSize
+    );
+  }, [customers, search, sorting, pagination]);
+
+  const columns = React.useMemo(
+    () => [
+      columnHelper.accessor('name', {
+        header: 'Name',
+        enableSorting: true,
+        sortLabel: 'Name',
+        sortAscLabel: 'A-Z',
+        sortDescLabel: 'Z-A',
+      }),
+      columnHelper.accessor('email', {
+        header: 'Email',
+        enableSorting: true,
+        sortLabel: 'Email',
+        sortAscLabel: 'A-Z',
+        sortDescLabel: 'Z-A',
+      }),
+      columnHelper.accessor('order_count', {
+        header: 'Order Count',
+        enableSorting: true,
+        sortLabel: 'Order Count',
+        sortAscLabel: 'Low to High',
+        sortDescLabel: 'High to Low',
+      }),
+      columnHelper.accessor('sales', {
+        header: 'Total Sales',
+        enableSorting: true,
+        sortLabel: 'Total Sales',
+        sortAscLabel: 'Low to High',
+        sortDescLabel: 'High to Low',
+        cell: ({ getValue }) => {
+          const sales = getValue();
+          return (
+            <p>
+              {new Intl.NumberFormat('en-US', {
+                style: 'currency',
+                currency: currencyCode || 'EUR',
+              }).format(sales || 0)}
+            </p>
+          );
+        },
+      }),
+      columnHelper.accessor('groups', {
+        header: 'Groups',
+        cell: ({ getValue }) => {
+          const groups = getValue();
+          return <p>{groups.length ? groups.join(', ') : 'No Group'}</p>;
+        },
+      }),
+      columnHelper.accessor('last_order', {
+        header: 'Last Order',
+        enableSorting: true,
+        sortLabel: 'Last Order',
+        sortAscLabel: 'Oldest to Newest',
+        sortDescLabel: 'Newest to Oldest',
+        cell: ({ getValue }) => {
+          const date = getValue();
+          return (
+            <p>
+              {date ? format(new Date(date), 'MMM dd, yyyy') : 'No orders yet'}
+            </p>
+          );
+        },
+      }),
+    ],
+    [currencyCode]
+  );
+
+  const table = useDataTable({
+    columns,
+    data: shownCustomers,
+    getRowId: (customer) => customer.customer_id,
+    rowCount: customers.length,
+    search: {
+      state: search,
+      onSearchChange: setSearch,
+    },
+    pagination: {
+      state: pagination,
+      onPaginationChange: setPagination,
+    },
+    sorting: {
+      state: sorting,
+      onSortingChange: setSorting,
+    },
+    onRowClick: (_, row) => {
+      // @ts-expect-error
+      navigate(`/customers/${row.original.customer_id}`);
+    },
+  });
+
+  return (
+    <DataTable instance={table}>
+      <DataTable.Toolbar className="px-0 pt-0">
+        <DataTable.Search placeholder="Search..." />
+      </DataTable.Toolbar>
+      <DataTable.Table
+        emptyState={{
+          filtered: {
+            heading: 'No customers found',
+          },
+          empty: {
+            heading: 'No customers available',
+          },
+        }}
+      />
+      {customers.length > PAGE_SIZE && <DataTable.Pagination />}
+    </DataTable>
+  );
+};

--- a/src/admin/components/CustomersTable.tsx
+++ b/src/admin/components/CustomersTable.tsx
@@ -54,16 +54,16 @@ export const CustomersTable: React.FC<CustomersTableProps> = ({
 
     if (sorting && sorting.id) {
       filtered = filtered.slice().sort((a, b) => {
-        // @ts-expect-error - TypeScript does not know the type of sorting.id
-        const aVal = a[sorting.id];
-        // @ts-expect-error - TypeScript does not know the type of sorting.id
-        const bVal = b[sorting.id];
-        if (aVal < bVal) {
-          return sorting.desc ? 1 : -1;
-        }
-        if (aVal > bVal) {
-          return sorting.desc ? -1 : 1;
-        }
+        const aVal = a[sorting.id as keyof typeof a];
+
+        const bVal = b[sorting.id as keyof typeof b];
+        if (!aVal && !bVal) return 0;
+
+        if (!aVal) return sorting.desc ? 1 : -1;
+        if (!bVal) return sorting.desc ? -1 : 1;
+
+        if (aVal < bVal) return sorting.desc ? 1 : -1;
+        if (aVal > bVal) return sorting.desc ? -1 : 1;
         return 0;
       });
     }

--- a/src/admin/components/StackedBarChart.tsx
+++ b/src/admin/components/StackedBarChart.tsx
@@ -83,7 +83,14 @@ export const StackedBarChart = <T extends Record<string, unknown>>({
           }}
         />
         {dataKeys?.map((key, index) => (
-          <Bar key={String(key)} dataKey={String(key)} fill={colors[index]} />
+          <Bar
+            key={String(key)}
+            dataKey={String(key)}
+            stackId="a"
+            fill={
+              useStableColors && colors.length > 0 ? colors[index] : '#3B82F6'
+            }
+          />
         ))}
       </RechartsBarChart>
     </ResponsiveContainer>

--- a/src/admin/components/StackedBarChart.tsx
+++ b/src/admin/components/StackedBarChart.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import {
+  BarChart as RechartsBarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { useDarkMode } from '../hooks/use-dark-mode';
+import { generateColorsForData } from '../lib/utils';
+
+type StackedBarChartProps<T extends Record<string, unknown>> = {
+  data: T[] | undefined;
+  xAxisDataKey: keyof T;
+  lineColor?: string;
+  yAxisTickFormatter?: (value: number) => string;
+  useStableColors?: boolean;
+  colorKeyField?: keyof T;
+  dataKeys: (keyof T)[];
+};
+
+export const StackedBarChart = <T extends Record<string, unknown>>({
+  data,
+  xAxisDataKey,
+  yAxisTickFormatter,
+  useStableColors = false,
+  colorKeyField,
+  dataKeys,
+}: StackedBarChartProps<T>) => {
+  const isDark = useDarkMode();
+
+  // Generate stable colors if requested
+  const colors = React.useMemo(() => {
+    if (!useStableColors || !data || !colorKeyField) {
+      return [];
+    }
+    return generateColorsForData(data, colorKeyField, 70, isDark ? 60 : 50);
+  }, [data, useStableColors, colorKeyField, isDark]);
+
+  return (
+    <ResponsiveContainer aspect={16 / 9}>
+      <RechartsBarChart data={data} margin={{ left: 20 }}>
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke={isDark ? '#374151' : '#E5E7EB'}
+        />
+        <XAxis
+          dataKey={String(xAxisDataKey)}
+          tick={{ fill: isDark ? '#D1D5DB' : '#6B7280' }}
+          axisLine={{ stroke: isDark ? '#4B5563' : '#D1D5DB' }}
+          tickLine={{ stroke: isDark ? '#4B5563' : '#D1D5DB' }}
+          tickMargin={10}
+        />
+        <YAxis
+          tickFormatter={yAxisTickFormatter}
+          allowDecimals={false}
+          tick={{ fill: isDark ? '#D1D5DB' : '#6B7280' }}
+          axisLine={{ stroke: isDark ? '#4B5563' : '#D1D5DB' }}
+          tickLine={{ stroke: isDark ? '#4B5563' : '#D1D5DB' }}
+        />
+        <Tooltip
+          cursor={{
+            fill: isDark ? 'rgba(55, 65, 81, 0.2)' : 'rgba(243, 244, 246, 0.5)',
+          }}
+          formatter={(value: number) =>
+            yAxisTickFormatter ? yAxisTickFormatter(value) : value
+          }
+          contentStyle={{
+            backgroundColor: isDark ? '#1F2937' : '#FFFFFF',
+            border: `1px solid ${isDark ? '#374151' : '#E5E7EB'}`,
+            borderRadius: '0.5rem',
+            color: isDark ? '#F9FAFB' : '#111827',
+            boxShadow: isDark
+              ? '0 4px 6px -1px rgba(0, 0, 0, 0.3)'
+              : '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
+          }}
+          labelStyle={{
+            color: isDark ? '#F9FAFB' : '#111827',
+            fontWeight: '500',
+            marginBottom: '4px',
+          }}
+        />
+        {dataKeys?.map((key, index) => (
+          <Bar key={String(key)} dataKey={String(key)} fill={colors[index]} />
+        ))}
+      </RechartsBarChart>
+    </ResponsiveContainer>
+  );
+};

--- a/src/admin/hooks/customer-analytics.tsx
+++ b/src/admin/hooks/customer-analytics.tsx
@@ -18,7 +18,7 @@ export type CustomerAnalyticsResponse = {
     sales: number;
     name: string;
     groups: string[];
-    count: number;
+    order_count: number;
     last_order: Date;
     email: string;
   }[];

--- a/src/admin/hooks/customer-analytics.tsx
+++ b/src/admin/hooks/customer-analytics.tsx
@@ -1,0 +1,39 @@
+import { DateRange } from 'react-day-picker';
+import { useQuery } from '@tanstack/react-query';
+import type { UseQueryOptions } from '@tanstack/react-query';
+import { retrieveCustomersAnalytics } from '../lib/data/customer-analytics';
+
+export type CustomerAnalyticsResponse = {
+  total_customers: number;
+  new_customers: number;
+  returning_customers: number;
+  customer_count: { name: string; count: number }[];
+  customer_group: { name: string; count: number }[];
+  customer_sales: {
+    customer_id: string;
+    sales: number;
+    name: string;
+    groups: string[];
+    count: number;
+    last_order: Date;
+    email: string;
+  }[];
+  currencyCode: string;
+};
+
+export const useCustomerAnalytics = (
+  query: DateRange | undefined,
+  options?: Omit<
+    UseQueryOptions<CustomerAnalyticsResponse | undefined, Error>,
+    'queryKey' | 'queryFn'
+  >
+) => {
+  return useQuery({
+    queryKey: ['customer-analytics', query?.from, query?.to],
+    queryFn: async () => {
+      const data = await retrieveCustomersAnalytics(query);
+      return data;
+    },
+    ...options,
+  });
+};

--- a/src/admin/hooks/customer-analytics.tsx
+++ b/src/admin/hooks/customer-analytics.tsx
@@ -18,7 +18,7 @@ export type CustomerAnalyticsResponse = {
     last_order: Date;
     email: string;
   }[];
-  currencyCode: string;
+  currency_code: string;
 };
 
 export const useCustomerAnalytics = (

--- a/src/admin/hooks/customer-analytics.tsx
+++ b/src/admin/hooks/customer-analytics.tsx
@@ -7,8 +7,12 @@ export type CustomerAnalyticsResponse = {
   total_customers: number;
   new_customers: number;
   returning_customers: number;
-  customer_count: { name: string; count: number }[];
-  customer_group: { name: string; count: number }[];
+  customer_count: {
+    name: string;
+    returning_customers: number;
+    new_customers: number;
+  }[];
+  customer_group: { name: string; total: number }[];
   customer_sales: {
     customer_id: string;
     sales: number;

--- a/src/admin/lib/data/customer-analytics.ts
+++ b/src/admin/lib/data/customer-analytics.ts
@@ -1,0 +1,17 @@
+import { DateRange } from 'react-day-picker';
+import { format } from 'date-fns';
+import { CustomerAnalyticsResponse } from '../../hooks/customer-analytics';
+const BACKEND_URL = __BACKEND_URL__ === '/' ? '' : __BACKEND_URL__;
+
+export async function retrieveCustomersAnalytics(date: DateRange | undefined) {
+  if (!date || !date.from || !date?.to) {
+    return undefined;
+  }
+  const dateFrom = format(date.from, 'yyyy-MM-dd');
+  const dateTo = format(date.to, 'yyyy-MM-dd');
+  const data = await fetch(
+    `${BACKEND_URL}/admin/agilo-analytics/customers?date_from=${dateFrom}&date_to=${dateTo}`
+  );
+  const customersAnalytics = (await data.json()) as CustomerAnalyticsResponse;
+  return customersAnalytics;
+}

--- a/src/admin/routes/analytics/page.tsx
+++ b/src/admin/routes/analytics/page.tsx
@@ -50,6 +50,8 @@ import { PieChartSkeleton } from '../../skeletons/PieChartSkeleton';
 import { ProductsTableSkeleton } from '../../skeletons/ProductsTableSkeleton';
 import { useCustomerAnalytics } from '../../hooks/customer-analytics';
 import { StackedBarChart } from '../../components/StackedBarChart';
+import { CustomersTableSkeleton } from '../../skeletons/CustomerTableSkeleton';
+import { CustomersTable } from '../../components/CustomersTable';
 
 // Helper functions to convert between DateRange and RangeValue<DateValue>
 function dateToCalendarDate(date: Date): CalendarDate {
@@ -672,7 +674,7 @@ const AnalyticsPage = () => {
                   </Container>
                 </div>
               </div>
-              <div className="flex max-md:flex-col gap-4">
+              <div className="flex max-md:flex-col gap-4 mb-4">
                 <div className="flex-1">
                   <Container className="min-h-[9.375rem]">
                     <Text size="xlarge" weight="plus">
@@ -692,7 +694,7 @@ const AnalyticsPage = () => {
                           xAxisDataKey="name"
                           lineColor="#82ca9d"
                           useStableColors={true}
-                          colorKeyField="name"
+                          colorKeyField="returning_customers"
                           dataKeys={['new_customers', 'returning_customers']}
                         />
                       </div>
@@ -744,6 +746,24 @@ const AnalyticsPage = () => {
                     )}
                   </Container>
                 </div>
+              </div>
+              <div className="flex gap-4 max-xl:flex-col">
+                <Container>
+                  <Text size="xlarge" weight="plus">
+                    Top Customers by Sales
+                  </Text>
+                  <Text size="small" className="mb-8 text-ui-fg-muted">
+                    Customers by sales in the selected period
+                  </Text>
+                  {isLoadingCustomers ? (
+                    <CustomersTableSkeleton />
+                  ) : (
+                    <CustomersTable
+                      customers={customers?.customer_sales || []}
+                      currencyCode={customers?.currency_code || 'EUR'}
+                    />
+                  )}
+                </Container>
               </div>
             </Tabs.Content>
           </div>

--- a/src/admin/routes/analytics/page.tsx
+++ b/src/admin/routes/analytics/page.tsx
@@ -15,6 +15,7 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
+  User,
 } from '@medusajs/icons';
 import { ChartNoAxesCombined } from 'lucide-react';
 import { subMonths, startOfMonth, endOfMonth, format, parse } from 'date-fns';
@@ -47,6 +48,7 @@ import { LineChartSkeleton } from '../../skeletons/LineChartSkeleton';
 import { BarChartSkeleton } from '../../skeletons/BarChartSkeleton';
 import { PieChartSkeleton } from '../../skeletons/PieChartSkeleton';
 import { ProductsTableSkeleton } from '../../skeletons/ProductsTableSkeleton';
+import { useCustomerAnalytics } from '../../hooks/customer-analytics';
 
 // Helper functions to convert between DateRange and RangeValue<DateValue>
 function dateToCalendarDate(date: Date): CalendarDate {
@@ -132,6 +134,9 @@ const AnalyticsPage = () => {
 
   const { data: products, isLoading: isLoadingProducts } =
     useProductAnalytics(date);
+
+  const { data: customers, isLoading: isLoadingCustomers } =
+    useCustomerAnalytics(date);
 
   const { data: orders, isLoading: isLoadingOrders } = useOrderAnalytics(
     ['this-month', 'last-month', 'last-3-months'].includes(rangeParam)
@@ -345,6 +350,12 @@ const AnalyticsPage = () => {
               disabled={isLoadingOrders || isLoadingProducts}
             >
               Products
+            </Tabs.Trigger>
+            <Tabs.Trigger
+              value="customers"
+              disabled={isLoadingOrders || isLoadingProducts}
+            >
+              Customers
             </Tabs.Trigger>
           </Tabs.List>
           <div className="mt-8">
@@ -592,6 +603,73 @@ const AnalyticsPage = () => {
                     />
                   )}
                 </Container>
+              </div>
+            </Tabs.Content>
+            <Tabs.Content value="customers">
+              <div className="flex max-md:flex-col gap-4 mb-4">
+                <div className="space-y-4 flex-1">
+                  <Container className="relative">
+                    <User className="absolute right-6 top-4 text-ui-fg-muted" />
+                    <Text size="small">Total Customers</Text>
+                    {isLoadingCustomers ? (
+                      <SmallCardSkeleton />
+                    ) : (
+                      <>
+                        <Text size="xlarge" weight="plus">
+                          {customers?.total_customers || 0}
+                        </Text>
+                      </>
+                    )}
+                  </Container>
+                  <Container className="relative">
+                    <User className="absolute right-6 top-4 text-ui-fg-muted" />
+                    <Text size="small">New Customers</Text>
+                    {isLoadingCustomers ? (
+                      <SmallCardSkeleton />
+                    ) : (
+                      <>
+                        <Text size="xlarge" weight="plus">
+                          {customers?.new_customers || 0}
+                        </Text>
+                      </>
+                    )}
+                  </Container>
+                </div>
+
+                <div className="space-y-4 flex-1">
+                  <Container className="relative">
+                    <User className="absolute right-6 text-ui-fg-muted top-4 size-[15px]" />
+                    <Text size="small">Returning Customers</Text>
+                    {isLoadingCustomers ? (
+                      <SmallCardSkeleton />
+                    ) : (
+                      <>
+                        <Text size="xlarge" weight="plus">
+                          {customers?.returning_customers || 0}
+                        </Text>
+                      </>
+                    )}
+                  </Container>
+                  <Container className="relative">
+                    <ChartNoAxesCombined className="absolute right-6 top-4 text-ui-fg-muted" />
+                    <Text size="small">Average Sales per Customer</Text>
+                    {isLoadingCustomers || isLoadingOrders ? (
+                      <SmallCardSkeleton />
+                    ) : (
+                      <>
+                        <Text size="xlarge" weight="plus">
+                          {new Intl.NumberFormat('en-US', {
+                            currency: customers?.currency_code || 'EUR',
+                            style: 'currency',
+                          }).format(
+                            (orders?.total_sales || 0) /
+                              (customers?.total_customers || 0)
+                          )}
+                        </Text>
+                      </>
+                    )}
+                  </Container>
+                </div>
               </div>
             </Tabs.Content>
           </div>

--- a/src/admin/routes/analytics/page.tsx
+++ b/src/admin/routes/analytics/page.tsx
@@ -49,6 +49,7 @@ import { BarChartSkeleton } from '../../skeletons/BarChartSkeleton';
 import { PieChartSkeleton } from '../../skeletons/PieChartSkeleton';
 import { ProductsTableSkeleton } from '../../skeletons/ProductsTableSkeleton';
 import { useCustomerAnalytics } from '../../hooks/customer-analytics';
+import { StackedBarChart } from '../../components/StackedBarChart';
 
 // Helper functions to convert between DateRange and RangeValue<DateValue>
 function dateToCalendarDate(date: Date): CalendarDate {
@@ -667,6 +668,79 @@ const AnalyticsPage = () => {
                           )}
                         </Text>
                       </>
+                    )}
+                  </Container>
+                </div>
+              </div>
+              <div className="flex max-md:flex-col gap-4">
+                <div className="flex-1">
+                  <Container className="min-h-[9.375rem]">
+                    <Text size="xlarge" weight="plus">
+                      New vs. Returning Customers
+                    </Text>
+                    <Text size="small" className="mb-8 text-ui-fg-muted">
+                      Distribution of new and returning customers in the
+                      selected period
+                    </Text>
+                    {isLoadingCustomers ? (
+                      <BarChartSkeleton />
+                    ) : customers?.customer_count &&
+                      customers.customer_count.length > 0 ? (
+                      <div className="w-full" style={{ aspectRatio: '16/9' }}>
+                        <StackedBarChart
+                          data={customers.customer_count}
+                          xAxisDataKey="name"
+                          lineColor="#82ca9d"
+                          useStableColors={true}
+                          colorKeyField="name"
+                          dataKeys={['new_customers', 'returning_customers']}
+                        />
+                      </div>
+                    ) : (
+                      <Text
+                        size="small"
+                        className="text-ui-fg-muted text-center"
+                      >
+                        No data available for the selected period.
+                      </Text>
+                    )}
+                  </Container>
+                </div>
+                <div className="flex-1">
+                  <Container className="min-h-[9.375rem]">
+                    <Text size="xlarge" weight="plus">
+                      Top Customer Groups by Sales
+                    </Text>
+                    <Text size="small" className="mb-8 text-ui-fg-muted">
+                      Sales breakdown by customer group in the selected period
+                    </Text>
+                    {isLoadingCustomers ? (
+                      <BarChartSkeleton />
+                    ) : customers?.customer_group &&
+                      customers.customer_group.length > 0 ? (
+                      <div className="w-full" style={{ aspectRatio: '16/9' }}>
+                        <BarChart
+                          data={customers.customer_group}
+                          xAxisDataKey="name"
+                          lineColor="#82ca9d"
+                          useStableColors={true}
+                          colorKeyField="name"
+                          yAxisDataKey="total"
+                          yAxisTickFormatter={(value: number) =>
+                            new Intl.NumberFormat('en-US', {
+                              currency: customers.currency_code || 'EUR',
+                              maximumFractionDigits: 0,
+                            }).format(value)
+                          }
+                        />
+                      </div>
+                    ) : (
+                      <Text
+                        size="small"
+                        className="text-ui-fg-muted text-center"
+                      >
+                        No data available for the selected period.
+                      </Text>
                     )}
                   </Container>
                 </div>

--- a/src/admin/routes/analytics/page.tsx
+++ b/src/admin/routes/analytics/page.tsx
@@ -58,7 +58,7 @@ function dateToCalendarDate(date: Date): CalendarDate {
   return new CalendarDate(
     date.getFullYear(),
     date.getMonth() + 1,
-    date.getDate()
+    date.getDate(),
   );
 }
 
@@ -72,7 +72,7 @@ function calendarDateToDate(calendarDate: DateValue): Date {
 }
 
 function dateRangeToRangeValue(
-  dateRange: DateRange | undefined
+  dateRange: DateRange | undefined,
 ): RangeValue<DateValue> | null {
   if (!dateRange?.from) return null;
   return {
@@ -84,7 +84,7 @@ function dateRangeToRangeValue(
 }
 
 function rangeValueToDateRange(
-  rangeValue: RangeValue<DateValue> | null
+  rangeValue: RangeValue<DateValue> | null,
 ): DateRange | undefined {
   if (!rangeValue) return undefined;
   return {
@@ -94,7 +94,7 @@ function rangeValueToDateRange(
 }
 
 function presetToDateRange(
-  preset: 'this-month' | 'last-month' | 'last-3-months'
+  preset: 'this-month' | 'last-month' | 'last-3-months',
 ): DateRange {
   const today = new Date();
   if (preset === 'this-month') return { from: startOfMonth(today), to: today };
@@ -145,19 +145,24 @@ const AnalyticsPage = () => {
     ['this-month', 'last-month', 'last-3-months'].includes(rangeParam)
       ? rangeParam
       : 'custom',
-    date
+    date,
   );
 
   const someOrderCountsGreaterThanZero = orders?.order_count?.some(
-    (item) => item.count > 0
+    (item) => item.count > 0,
   );
 
   const someOrderSalesGreaterThanZero = orders?.order_sales?.some(
-    (item) => item.sales > 0
+    (item) => item.sales > 0,
   );
 
   const someTopSellingProductsGreaterThanZero =
     products?.variantQuantitySold?.some((item) => item.quantity > 0);
+
+  const someCustomerCountsGreaterThanZero = customers?.customer_count?.some(
+    (item) =>
+      (item.new_customers || 0) > 0 || (item.returning_customers || 0) > 0,
+  );
 
   const updateDatePreset = React.useCallback(
     (preset: string) => {
@@ -186,15 +191,15 @@ const AnalyticsPage = () => {
               'range',
               `${format(currentDate.from || new Date(), 'yyyy-MM-dd')}-${format(
                 currentDate.to || new Date(),
-                'yyyy-MM-dd'
-              )}`
+                'yyyy-MM-dd',
+              )}`,
             );
           }
           break;
       }
       setSearchParams(params);
     },
-    [searchParams, rangeParam, setSearchParams]
+    [searchParams, rangeParam, setSearchParams],
   );
 
   const updateUrlParams = React.useCallback(
@@ -205,13 +210,13 @@ const AnalyticsPage = () => {
           'range',
           `${format(value.from, 'yyyy-MM-dd')}-${format(
             value.to,
-            'yyyy-MM-dd'
-          )}`
+            'yyyy-MM-dd',
+          )}`,
         );
       }
       setSearchParams(params);
     },
-    [searchParams, setSearchParams]
+    [searchParams, setSearchParams],
   );
 
   // Handle date range changes and automatically switch to custom
@@ -220,7 +225,7 @@ const AnalyticsPage = () => {
       const newDateRange = rangeValueToDateRange(value);
       updateUrlParams(newDateRange);
     },
-    [updateUrlParams]
+    [updateUrlParams],
   );
 
   return (
@@ -235,7 +240,7 @@ const AnalyticsPage = () => {
               defaultValue="this-month"
               value={
                 ['this-month', 'last-month', 'last-3-months'].includes(
-                  rangeParam
+                  rangeParam,
                 )
                   ? rangeParam
                   : 'custom'
@@ -581,7 +586,7 @@ const AnalyticsPage = () => {
                     <ProductsTable
                       products={
                         products?.lowStockVariants?.filter(
-                          (product) => product.inventoryQuantity === 0
+                          (product) => product.inventoryQuantity === 0,
                         ) || []
                       }
                     />
@@ -600,7 +605,7 @@ const AnalyticsPage = () => {
                     <ProductsTable
                       products={
                         products?.lowStockVariants?.filter(
-                          (product) => product.inventoryQuantity > 0
+                          (product) => product.inventoryQuantity > 0,
                         ) || []
                       }
                     />
@@ -665,8 +670,11 @@ const AnalyticsPage = () => {
                             currency: customers?.currency_code || 'EUR',
                             style: 'currency',
                           }).format(
-                            (orders?.total_sales || 0) /
-                              (customers?.total_customers || 0)
+                            customers?.total_customers &&
+                              customers.total_customers > 0
+                              ? (orders?.total_sales || 0) /
+                                  customers.total_customers
+                              : 0,
                           )}
                         </Text>
                       </>
@@ -687,7 +695,8 @@ const AnalyticsPage = () => {
                     {isLoadingCustomers ? (
                       <BarChartSkeleton />
                     ) : customers?.customer_count &&
-                      customers.customer_count.length > 0 ? (
+                      customers.customer_count.length > 0 &&
+                      someCustomerCountsGreaterThanZero ? (
                       <div className="w-full" style={{ aspectRatio: '16/9' }}>
                         <StackedBarChart
                           data={customers.customer_count}

--- a/src/admin/skeletons/CustomerTableSkeleton.tsx
+++ b/src/admin/skeletons/CustomerTableSkeleton.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import {
+  createDataTableColumnHelper,
+  useDataTable,
+  DataTable,
+} from '@medusajs/ui';
+
+import { Skeleton } from '../components/Skeleton';
+
+const dummyData = [
+  {
+    a: 'a',
+    b: 'b',
+    c: 0,
+    d: 0,
+    e: new Date(),
+  },
+  {
+    a: 'a',
+    b: 'b',
+    c: 0,
+    d: 0,
+    e: new Date(),
+  },
+  {
+    a: 'a',
+    b: 'b',
+    c: 0,
+    d: 0,
+    e: new Date(),
+  },
+  {
+    a: 'a',
+    b: 'b',
+    c: 0,
+    d: 0,
+    e: new Date(),
+  },
+  {
+    a: 'a',
+    b: 'b',
+    c: 0,
+    d: 0,
+    e: new Date(),
+  },
+  {
+    a: 'a',
+    b: 'b',
+    c: 0,
+    d: 0,
+    e: new Date(),
+  },
+];
+
+const columnHelper = createDataTableColumnHelper<(typeof dummyData)[0]>();
+
+const columns = [
+  columnHelper.accessor('a', {
+    header: () => null,
+    cell: () => <Skeleton className="w-full h-5" />,
+  }),
+  columnHelper.accessor('b', {
+    header: () => null,
+    cell: () => <Skeleton className="w-full h-5" />,
+  }),
+  columnHelper.accessor('c', {
+    header: () => null,
+    cell: () => <Skeleton className="w-full h-5" />,
+  }),
+  columnHelper.accessor('d', {
+    header: () => null,
+    cell: () => <Skeleton className="w-full h-5" />,
+  }),
+  columnHelper.accessor('e', {
+    header: () => null,
+    cell: () => <Skeleton className="w-full h-5" />,
+  }),
+];
+
+export const CustomersTableSkeleton = () => {
+  const [search, setSearch] = React.useState<string>('');
+
+  const table = useDataTable({
+    columns,
+    data: dummyData,
+    getRowId: (customer) => customer.a,
+    rowCount: dummyData.length,
+    search: {
+      state: search,
+      onSearchChange: setSearch,
+    },
+  });
+
+  return (
+    <DataTable instance={table}>
+      <DataTable.Toolbar className="px-0 pt-0">
+        <DataTable.Search placeholder="Search..." />
+      </DataTable.Toolbar>
+      <DataTable.Table />
+    </DataTable>
+  );
+};

--- a/src/api/admin/agilo-analytics/customers/route.ts
+++ b/src/api/admin/agilo-analytics/customers/route.ts
@@ -95,13 +95,17 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     }, {})
   );
 
-  const newCustomers = customers.filter((customer) =>
-    //@ts-ignore
-    customer?.orders?.every(
-      (order) =>
-        new Date(order.created_at) >=
-        new Date(result.data.date_from + 'T00:00:00Z')
-    )
+  const newCustomers = customers.filter(
+    (customer) =>
+      customer &&
+      typeof customer === 'object' &&
+      'orders' in customer &&
+      Array.isArray(customer.orders) &&
+      customer?.orders?.every(
+        (order) =>
+          new Date(order.created_at) >=
+          new Date(result.data.date_from + 'T00:00:00Z')
+      )
   );
 
   const calculateDateRange = calculateDateRangeMethod['custom'];
@@ -165,11 +169,16 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
         newCustomers: new Set<string>(),
       };
     }
-    //@ts-ignore
-    if (newCustomers.some((c) => c?.id === order.customer?.id)) {
-      groupedByKey[key].newCustomers.add(order.customer?.id);
-      //@ts-ignore
-    } else if (order.customer?.id) {
+    if (
+      order.customer &&
+      order.customer.id &&
+      newCustomers.some(
+        (c) =>
+          c && typeof c === 'object' && 'id' in c && c.id === order.customer.id
+      )
+    ) {
+      groupedByKey[key].newCustomers.add(order.customer.id);
+    } else if (order.customer && order.customer.id) {
       groupedByKey[key].returningCustomers.add(order.customer.id);
     }
 

--- a/src/api/admin/agilo-analytics/customers/route.ts
+++ b/src/api/admin/agilo-analytics/customers/route.ts
@@ -241,7 +241,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     customer_count: customerCountArray,
     customer_group: customerGroupArray,
     customer_sales: customerSalesArray.slice(0, 10),
-    currencyCode,
+    currency_code: currencyCode,
   };
 
   res.json(customerData);

--- a/src/api/admin/agilo-analytics/customers/route.ts
+++ b/src/api/admin/agilo-analytics/customers/route.ts
@@ -189,7 +189,10 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     if (order?.customer?.id && !customerSales[order.customer.id]) {
       customerSales[order.customer.id] = {
         sales: 0,
-        name: order.customer?.first_name + ' ' + order.customer?.last_name,
+        name:
+          (order.customer?.first_name || '') +
+          ' ' +
+          (order.customer?.last_name || ''),
         groups: order.customer?.groups?.map((g) => g.name) || [],
         count: 0,
         last_order: new Date(order.created_at),
@@ -228,7 +231,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
       sales: customer.sales,
       name: customer.name,
       groups: customer.groups,
-      count: customer.count,
+      order_count: customer.count,
       last_order: customer.last_order,
       email: customer.email,
     }))

--- a/src/api/admin/agilo-analytics/customers/route.ts
+++ b/src/api/admin/agilo-analytics/customers/route.ts
@@ -51,6 +51,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
   const customerData = {
     total_customers: customers.length,
     new_customers: newCustomers.length,
+    returning_customers: customers.length - newCustomers.length,
   };
 
   res.json(customerData);

--- a/src/api/admin/agilo-analytics/customers/route.ts
+++ b/src/api/admin/agilo-analytics/customers/route.ts
@@ -1,0 +1,49 @@
+import { MedusaRequest, MedusaResponse } from '@medusajs/framework';
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from '@medusajs/framework/utils';
+import { z } from 'zod';
+
+export const adminCustomerAnalyticsQuerySchema = z.object({
+  date_from: z.string(),
+  date_to: z.string(),
+});
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const result = adminCustomerAnalyticsQuerySchema.safeParse(req.query);
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY);
+
+  if (!result.success) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      result.error.errors.map((err) => err.message).join(', ')
+    );
+  }
+  const { data: orders } = await query.graph({
+    entity: 'order',
+    fields: ['id', 'created_at', 'customer.*', 'customer.orders.*'],
+    filters: {
+      created_at: {
+        $gte: result.data.date_from,
+        $lte: result.data.date_to,
+      },
+      status: { $nin: ['draft', 'canceled'] },
+    },
+  });
+
+  const customers = Object.values(
+    orders.reduce((acc, { customer }) => {
+      if (customer && !acc[customer.id]) {
+        acc[customer.id] = customer;
+      }
+      return acc;
+    }, {})
+  );
+
+  const customerData = {
+    total_customers: customers.length,
+  };
+
+  res.json(customerData);
+}

--- a/src/api/admin/agilo-analytics/customers/route.ts
+++ b/src/api/admin/agilo-analytics/customers/route.ts
@@ -25,8 +25,8 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     fields: ['id', 'created_at', 'customer.*', 'customer.orders.*'],
     filters: {
       created_at: {
-        $gte: result.data.date_from,
-        $lte: result.data.date_to,
+        $gte: result.data.date_from + 'T00:00:00Z',
+        $lte: result.data.date_to + 'T23:59:59.999Z',
       },
       status: { $nin: ['draft', 'canceled'] },
     },
@@ -41,8 +41,16 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     }, {})
   );
 
+  const newCustomers = customers.filter((customer) =>
+    //@ts-ignore
+    customer?.orders?.every(
+      (order) => order.created_at >= result.data.date_from
+    )
+  );
+
   const customerData = {
     total_customers: customers.length,
+    new_customers: newCustomers.length,
   };
 
   res.json(customerData);

--- a/src/api/admin/agilo-analytics/customers/route.ts
+++ b/src/api/admin/agilo-analytics/customers/route.ts
@@ -243,7 +243,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     returning_customers: customers.length - newCustomers.length,
     customer_count: customerCountArray,
     customer_group: customerGroupArray,
-    customer_sales: customerSalesArray.slice(0, 10),
+    customer_sales: customerSalesArray,
     currency_code: currencyCode,
   };
 

--- a/src/api/admin/agilo-analytics/customers/route.ts
+++ b/src/api/admin/agilo-analytics/customers/route.ts
@@ -3,7 +3,14 @@ import {
   ContainerRegistrationKeys,
   MedusaError,
 } from '@medusajs/framework/utils';
+import { format } from 'date-fns';
 import { z } from 'zod';
+
+import {
+  calculateDateRangeMethod,
+  getAllDateGroupingKeys,
+  getDateGroupingKey,
+} from '../../../../utils/orders';
 
 export const adminCustomerAnalyticsQuerySchema = z.object({
   date_from: z.string(),
@@ -44,14 +51,75 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
   const newCustomers = customers.filter((customer) =>
     //@ts-ignore
     customer?.orders?.every(
-      (order) => order.created_at >= result.data.date_from
+      (order) =>
+        new Date(order.created_at) >=
+        new Date(result.data.date_from + 'T00:00:00Z')
     )
   );
+
+  const calculateDateRange = calculateDateRangeMethod['custom'];
+  if (!calculateDateRange) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      'Invalid preset value'
+    );
+  }
+
+  const { days, current } = calculateDateRange({
+    ...result.data,
+    preset: 'custom',
+  });
+
+  const currentFrom = format(current.start, 'yyyy-MM-dd');
+  const currentTo = format(current.end, 'yyyy-MM-dd');
+
+  let groupBy: 'day' | 'week' | 'month' = 'day';
+  if (days > 120) {
+    groupBy = 'month';
+  } else if (days > 30) {
+    groupBy = 'week';
+  }
+
+  const keyRange = getAllDateGroupingKeys(groupBy, currentFrom, currentTo);
+
+  const groupedByKey: Record<
+    string,
+    { returningCustomers: Set<string>; newCustomers: Set<string> }
+  > = {};
+
+  for (const order of orders) {
+    const key = getDateGroupingKey(
+      new Date(order.created_at),
+      groupBy,
+      currentFrom,
+      currentTo
+    );
+    if (!groupedByKey[key]) {
+      groupedByKey[key] = {
+        returningCustomers: new Set<string>(),
+        newCustomers: new Set<string>(),
+      };
+    }
+    //@ts-ignore
+    if (newCustomers.some((c) => c?.id === order.customer?.id)) {
+      groupedByKey[key].newCustomers.add(order.customer?.id);
+      //@ts-ignore
+    } else if (order.customer?.id) {
+      groupedByKey[key].returningCustomers.add(order.customer.id);
+    }
+  }
+
+  const customerCountArray = keyRange.map((date) => ({
+    name: date,
+    returning_customers: groupedByKey[date]?.returningCustomers.size || 0,
+    new_customers: groupedByKey[date]?.newCustomers.size || 0,
+  }));
 
   const customerData = {
     total_customers: customers.length,
     new_customers: newCustomers.length,
     returning_customers: customers.length - newCustomers.length,
+    customer_count: customerCountArray,
   };
 
   res.json(customerData);


### PR DESCRIPTION
Add a new Customers tab to the Analytics admin page that mirrors the Orders tab structure. The goal is to give admins a quick view of customer acquisition and group-based sales performance within the selected date range.