### PR TITLE
fix: read validation issues from error.issues, not error.errors (zod 4)

### DIFF
--- a/src/api/admin/agilo-analytics/customers/route.ts
+++ b/src/api/admin/agilo-analytics/customers/route.ts
@@ -64,7 +64,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
   if (!result.success) {
     throw new MedusaError(
       MedusaError.Types.INVALID_DATA,
-      result.error.errors.map((err) => err.message).join(', '),
+      result.error.issues.map((err) => err.message).join(', '),
     );
   }
   const { data: orders } = (await query.graph({

--- a/src/api/admin/agilo-analytics/orders/route.ts
+++ b/src/api/admin/agilo-analytics/orders/route.ts
@@ -42,7 +42,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
   if (!result.success) {
     throw new MedusaError(
       MedusaError.Types.INVALID_DATA,
-      result.error.errors.map((err) => err.message).join(', '),
+      result.error.issues.map((err) => err.message).join(', '),
     );
   }
   const validatedQuery = result.data;

--- a/src/api/admin/agilo-analytics/products/route.ts
+++ b/src/api/admin/agilo-analytics/products/route.ts
@@ -19,7 +19,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
   if (!result.success) {
     throw new MedusaError(
       MedusaError.Types.INVALID_DATA,
-      result.error.errors.map((err) => err.message).join(', '),
+      result.error.issues.map((err) => err.message).join(', '),
     );
   }
   const validatedQuery = result.data;


### PR DESCRIPTION
## The problem

All three analytics routes build their validation error message like this:

```ts
result.error.errors.map((err) => err.message).join(', ')
```

Under **zod 4**, `ZodError` exposes `issues` and no longer exposes `errors`. So `result.error.errors` is `undefined` and the `.map` throws:

```
TypeError: Cannot read properties of undefined (reading 'map')
    at GET (src/api/admin/agilo-analytics/products/route.ts:21:27)
```

Because this happens *inside* the `if (!result.success)` branch, the failure replaces the intended 400. The caller gets:

```json
{"code":"unknown_error","type":"unknown_error","message":"An unknown error occurred."}
```

The real cause is only visible in the server log.

## Why it matters

Medusa 2.19 resolves **zod 4.2.0**, so this reproduces on a current Medusa install. The practical effect is that all three routes become undiagnosable from the client: any wrong parameter returns an opaque 500 instead of a message naming it.

It is also what makes `/products` and `/customers` *look* broken when they are simply being called with the wrong shape. Those two accept `date_from`/`date_to` while `/orders` accepts `preset`, so calling them the way you'd call `/orders` returns a 500 with no hint that the parameter names differ — which is how I ran into this.

## The fix

Read `issues` instead of `errors`.

`issues` is present in **both** major versions — in zod 3 `errors` is an alias for it — so no version detection or fallback is needed and the plugin keeps working across the whole supported Medusa range. Verified directly:

| zod | `error.issues` | `error.errors` |
|-----|---------------|----------------|
| 3.25.76 | ✅ | ✅ |
| 4.2.0 | ✅ | ❌ |

## After

```
GET /admin/agilo-analytics/orders?preset=not-a-preset
400 {"type":"invalid_data","message":"Invalid input"}

GET /admin/agilo-analytics/products?date_from=oops
400 {"type":"invalid_data","message":"Invalid input: expected string, received undefined"}
```

Three files, one word each. No behaviour change on the success path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
