### PR TITLE
fix: exclude cancelled orders from order totals and sales

### DIFF
--- a/src/api/admin/agilo-analytics/orders/route.ts
+++ b/src/api/admin/agilo-analytics/orders/route.ts
@@ -31,6 +31,7 @@ export const adminOrdersListQuerySchema = z.discriminatedUnion('preset', [
   }),
 ]);
 const DEFAULT_CURRENCY = 'EUR';
+const CANCELED_STATUS = 'canceled';
 
 function getPercentChange(current: number, previous: number) {
   if (previous === 0) return current === 0 ? 0 : 100;
@@ -153,7 +154,22 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
   const groupedByKey: Record<string, { orderCount: number; sales: number }> =
     {};
 
+  let totalOrders = 0;
+
   for (const order of orders) {
+    // Tallied before the cancelled orders are skipped, so the status breakdown
+    // stays a complete picture of the period. It is the only place in the UI
+    // where a merchant can see cancellations at all.
+    if (order.status) {
+      statuses[order.status] = (statuses[order.status] ?? 0) + 1;
+    }
+
+    if (order.status === CANCELED_STATUS) {
+      continue;
+    }
+
+    totalOrders += 1;
+
     const exchangeRate =
       order.currency_code.toUpperCase() !== currencyCode
         ? exchangeRates?.rates[order.currency_code.toUpperCase()]
@@ -180,14 +196,19 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
       regions[order.region.name] =
         (regions[order.region.name] ?? 0) + orderTotal;
     }
-
-    if (order.status) {
-      statuses[order.status] = (statuses[order.status] ?? 0) + 1;
-    }
   }
 
   let prevTotalSales = 0;
+  let prevTotalOrders = 0;
   for (const order of prevRangeOrders) {
+    // Excluded from the comparison period too, otherwise every percentage
+    // change is measured against a differently-defined baseline.
+    if (order.status === CANCELED_STATUS) {
+      continue;
+    }
+
+    prevTotalOrders += 1;
+
     const exchangeRate =
       order.currency_code.toUpperCase() !== currencyCode
         ? exchangeRates?.rates[order.currency_code.toUpperCase()]
@@ -195,9 +216,8 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     const orderTotal = new BigNumber(order.total).numeric / exchangeRate;
     prevTotalSales += orderTotal;
   }
-  const prevTotalOrders = prevRangeOrders.length;
 
-  const percentOrders = getPercentChange(orders.length, prevTotalOrders);
+  const percentOrders = getPercentChange(totalOrders, prevTotalOrders);
   const percentSales = getPercentChange(totalSales, prevTotalSales);
 
   const salesArray = keyRange.map((date) => ({
@@ -224,7 +244,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
   }));
 
   res.json({
-    total_orders: orders.length,
+    total_orders: totalOrders,
     prev_orders_percent: percentOrders,
     regions: regionsArray,
     total_sales: totalSales,


### PR DESCRIPTION
## The problem

The orders route fetches with only:

```ts
status: { $nin: ['draft'] },
```

so a **cancelled order still counts as trade**. It inflates Total Orders, Total Sales, Sales Over Time, Orders Over Time and Top Regions by Sales. The overstatement scales with the cancellation rate — worst exactly when a merchant most needs an accurate number.

## The plugin already disagrees with itself

`src/api/admin/agilo-analytics/customers/route.ts` filters:

```ts
status: { $nin: ['draft', 'canceled'] },
```

So today the Customers tab treats a cancelled order as not-trade while the Orders tab treats it as trade, over the same period and the same store. This PR makes the orders route agree with the customers route rather than introducing a new opinion.

## Why the loop and not the query filter

Excluding `canceled` in the `query.graph` filter would be the smaller diff, but it would also remove cancellations from **Order Status Breakdown** — the only place in the UI where a merchant can see them at all. So the tally is moved above the skip:

- `statuses` counts every order, cancelled included → the pie is unchanged
- everything downstream of the skip ignores cancelled → the KPIs and series become honest

The comparison period gets the same treatment, otherwise `prev_orders_percent` and `prev_sales_percent` compare a cancelled-exclusive current period against a cancelled-inclusive previous one.

## Verification

Against a store with 120 orders across four months, two regions and two currencies (USD + EUR). For a 30-day window containing 59 orders, 15 of them cancelled:

| | before | after |
|---|---|---|
| `total_orders` | 59 | **44** |
| `order_count` series sums to `total_orders` | ✅ | ✅ |
| region sales reconcile with `total_sales` | ✅ | ✅ |
| cancellations still in `statuses` | 15 | **15** |

## Note on scope

This changes reported figures, so it will look like a regression to anyone who has been reading the current numbers. If you would rather have it behind a plugin option (`include_cancelled`, defaulting to today's behaviour) than as a straight fix, say the word and I'll rework it — though given the customers route already excludes them, I think consistency is the better default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
